### PR TITLE
Add codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  branch: master
+
+coverage:
+  precision: 2
+  round: nearest
+  range: 5...50
+
+  status:
+    project:
+      default:
+        target: 1.0%
+        threshold: 5.0%
+        branches:
+          - master
+        if_no_uploads: error
+
+    patch:
+      default:
+        target: 0.0%
+        threshold: 10.0%
+        if_no_uploads: error
+
+    changes: true
+
+  ignore:
+    - .*/ContactBrowserTests/.*
+
+comment:
+  layout: "header, diff, changes, suggestions"
+  behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,8 @@ coverage:
 
   ignore:
     - .*/ContactBrowserTests/.*
+    - *ViewController.swift
+    - AppDelegate.swift
 
 comment:
   layout: "header, diff, changes, suggestions"


### PR DESCRIPTION
As an effort to testify Codecov as coverage CI tool for Intrepid Jenkins server, this PR adds code coverage settings, following the Travis CI set up and basic Codecov integration from #1.
